### PR TITLE
Adding the -j flag for builds using the -v flag

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -126,7 +126,7 @@ BuildLib()
         ${BuildScript} -c
     fi
     if [ ${VERBOSE} = 1 ]; then
-        ${BuildScript} -v
+        ${BuildScript} -v -j ${NumProc}
     else
         ${BuildScript} -j ${NumProc}
     fi


### PR DESCRIPTION
Seems like if you set -v (verbosity), you wouldn't get multiple build jobs to spawn.  