### PR TITLE
Update readme.md to include option how to create installer packages from build

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ To start the build inside of a docker container you can clone the repository and
 ```
 This will do a full build of the project with the output being placed into the `out` directory.  For more options see `runbuild.sh -h`.
 
+Additionally in order to build and create the installer packages you can pass in the -createinstaller option to the script 
+```
+./runbuild.sh -createinstaller
+```
+
 #### Optional: Build the container locally
 If you would prefer to build the container locally, you can run the following script:
 ```


### PR DESCRIPTION
Currently, the readme does not include information on how to create an installer package (debian). Update to include that information. More updates are coming on how to install using these packages and test with a local dev cluster environment