### PR TITLE
runbuild.sh - add support for whitespaces in directory path

### DIFF
--- a/connect.sh
+++ b/connect.sh
@@ -31,7 +31,6 @@ done
 CDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DOCKER_VERSION=`cat "$CDIR"/DOCKER_VERSION`
 OUT_DIR=$CDIR/out
-winp
 echo "Running container version $DOCKER_VERSION"
 # net=host for connection on corpnet
 # cap-add SYS_PTRACE for strace to work.

--- a/connect.sh
+++ b/connect.sh
@@ -29,9 +29,9 @@ done
 # change directory to the one containing this script and
 # record this directories full path.
 CDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-DOCKER_VERSION=`cat $CDIR/DOCKER_VERSION`
+DOCKER_VERSION=`cat "$CDIR"/DOCKER_VERSION`
 OUT_DIR=$CDIR/out
-
+winp
 echo "Running container version $DOCKER_VERSION"
 # net=host for connection on corpnet
 # cap-add SYS_PTRACE for strace to work.
@@ -43,8 +43,8 @@ docker run \
     --net=host \
     --cap-add NET_ADMIN \
     -ti \
-    -v $OUT_DIR:/out \
-    -v $CDIR/deps:/deps \
-    -v $CDIR/src:/src \
+    -v "$OUT_DIR":/out \
+    -v "$CDIR"/deps:/deps \
+    -v "$CDIR"/src:/src \
     microsoft/service-fabric-build-ubuntu:$DOCKER_VERSION \
     bash -i

--- a/runbuild.sh
+++ b/runbuild.sh
@@ -2,11 +2,11 @@
 
 # get the current directory
 CDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-DOCKER_VERSION=`cat $CDIR/DOCKER_VERSION`
+DOCKER_VERSION=`cat "$CDIR"/DOCKER_VERSION`
 
 OUT_DIR=$CDIR/out
 
-mkdir -p $OUT_DIR
+mkdir -p "$OUT_DIR"
 
 BUILD_PARAMS=""
 while (( "$#" )); do
@@ -33,9 +33,9 @@ docker run \
     --net=host \
     --cap-add=NET_ADMIN \
     -ti \
-    -v $OUT_DIR:/out \
-    -v $CDIR/deps:/deps \
-    -v $CDIR/src:/src \
+    -v "$OUT_DIR":/out \
+    -v "$CDIR"/deps:/deps \
+    -v "$CDIR"/src:/src \
     -e "BUILD_PARAMS=$BUILD_PARAMS" \
     microsoft/service-fabric-build-ubuntu:$DOCKER_VERSION \
     bash -c 'echo $BUILD_PARAMS && cd /out/ && /src/build.sh -all -d $BUILD_PARAMS'


### PR DESCRIPTION
If current directory full path contains whitespaces then `runbuild.sh -c -n` command fails.
Added small changes to support directory names with whitespaces.