### PR TITLE
Adding docs on how to deploy local cluster from build output

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Take note to replace the above command with your actual local DNS server, and re
 service docker restart
 ```
 
+## Running a local cluster
+For more details please refer [Deploying local cluster from build](docs/install_packages_and_deploy_cluster.md)
+
 ## Documentation 
 Service Fabric conceptual and reference documentation is available at [docs.microsoft.com/azure/service-fabric](https://docs.microsoft.com/azure/service-fabric/). Documentation is also open to your contribution on GitHub at [github.com/Microsoft/azure-docs](https://github.com/Microsoft/azure-docs).
 ## Samples 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,1 @@
-# This folder is a placeholder for repo docs while we transition to a wiki or docs repo 
+### This folder is a placeholder for repo docs while we transition to a wiki or docs repo 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+# This folder is a placeholder for repo docs while we transition to a wiki or docs repo 

--- a/docs/install_packages_and_deploy_cluster.md
+++ b/docs/install_packages_and_deploy_cluster.md
@@ -1,0 +1,95 @@
+
+# How to install the packages and deploy local cluster on Linux
+
+To deploy and run a cluster on your Linux development machine, install the runtime and common SDK generated as the build output. 
+
+## Prerequisites
+
+The following operating system versions are supported for development:
+
+* Ubuntu 16.04 (`Xenial Xerus`)
+
+Ensure you have run the build using the -createinstaller option to generate the debian files
+```
+./runbuild.sh -createinstaller
+```
+
+## Installation steps
+
+### Update your APT sources
+To install the SDK and the associated runtime package via the apt-get command-line tool, you must first update your Advanced Packaging Tool (APT) sources.
+
+1. Open a terminal.
+
+2. Add the `dotnet` repo to your sources list.
+
+    ```bash
+    sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ xenial main" > /etc/apt/sources.list.d/dotnetdev.list'
+    ```
+
+3. Add the new Gnu Privacy Guard (GnuPG, or GPG) key to your APT keyring.
+
+    ```bash
+    sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
+    ```
+
+4. Add the official Docker GPG key to your APT keyring.
+
+    ```bash
+    sudo apt-get install curl
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    ```
+
+5. Set up the Docker repository.
+
+    ```bash
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    ```
+
+6. Refresh your package lists based on the newly added repositories.
+
+    ```bash
+    sudo apt-get update
+    ```
+
+### Install and set up the Service Fabric Debians for local cluster setup
+
+After you have updated your sources, you can install the runtime and SDK, confirm the installation, and agree to the license agreement. Please cd to the location in the output directory where the debians are placed i.e. repo.root/out/build.prod/FabricDrop/deb/. Install the runtime and sdk Debian packages named as servicefabric_x.x.x.x.deb and servicefabric_sdkcommon_y.y.y.deb, where x.x.x.x and y.y.y is the actual version numbers in the same of the file. Please replace the commands below with the actual files names in the folder 
+
+```bash
+sudo dpkg -i servicefabric_x.x.x.x.deb
+sudo apt-get install -fy
+sudo dpkg -i servicefabric_sdkcommon_x.x.x.deb
+sudo apt-get install -fy
+```
+
+>   [!TIP]
+>   The following commands automate accepting the license for Service Fabric packages:
+>   ```bash
+>   echo "servicefabric servicefabric/accepted-eula-ga select true" | sudo debconf-set-selections
+>   echo "servicefabricsdkcommon servicefabricsdkcommon/accepted-eula-ga select true" | sudo debconf-set-selections
+>   ```
+
+## Set up a local cluster
+  Once the installation completes, you should be able to start a local cluster.
+
+  1. Run the cluster setup script.
+
+      ```bash
+      sudo /opt/microsoft/sdk/servicefabric/common/clustersetup/devclustersetup.sh
+      ```
+
+  2. Open a web browser and go to [Service Fabric Explorer](http://localhost:19080/Explorer). If the cluster has started, you should see the Service Fabric Explorer dashboard.
+
+  At this point, you can deploy pre-built Service Fabric application packages or new ones based on guest containers or guest executables. Please check out more details at [How to run some sample projects](https://azure.microsoft.com/resources/samples/?sort=0&service=service-fabric).
+
+
+>   [!TIP]
+    If you have an SSD disk avaiable, it is recommended to pass an SSD folder path using `--clusterdataroot` with devclustersetup.sh for superior performance.
+
+## Set up the Service Fabric CLI
+
+The [Service Fabric CLI](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cli) has commands for interacting with Service Fabric entities,
+including clusters and applications.
+Follow the instructions at [Service Fabric CLI](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cli) to install the CLI.

--- a/docs/install_packages_and_deploy_cluster.md
+++ b/docs/install_packages_and_deploy_cluster.md
@@ -55,16 +55,13 @@ To install the SDK and the associated runtime package via the apt-get command-li
 
 ### Install and set up the Service Fabric Debians for local cluster setup
 
-After you have updated your sources, you can install the runtime and SDK, confirm the installation, and agree to the license agreement. Please cd to the location in the output directory where the debians are placed i.e. repo.root/out/build.prod/FabricDrop/deb/. Install the runtime and sdk Debian packages named as servicefabric_x.x.x.x.deb and servicefabric_sdkcommon_y.y.y.deb, where x.x.x.x and y.y.y is the actual version numbers in the same of the file. Please replace the commands below with the actual files names in the folder 
+After you have updated your sources, you can install the runtime and SDK, confirm the installation, and agree to the license agreement. Please cd to the location in the output directory where the debians are placed i.e. out/build.prod/FabricDrop/deb/. Install the runtime and sdk Debian packages named as servicefabric_x.x.x.x.deb and servicefabric_sdkcommon_y.y.y.deb, where x.x.x.x and y.y.y is the actual version numbers in the same of the file. Please replace the commands below with the actual files names in the folder 
 
 ```bash
-sudo dpkg -i servicefabric_x.x.x.x.deb
-sudo apt-get install -fy
-sudo dpkg -i servicefabric_sdkcommon_x.x.x.deb
-sudo apt-get install -fy
+sudo dpkg -i servicefabric_x.x.x.x.deb && sudo apt-get install -fy
+sudo dpkg -i servicefabric_sdkcommon_x.x.x.deb && sudo apt-get install -fy
 ```
 
->   [!TIP]
 >   The following commands automate accepting the license for Service Fabric packages:
 >   ```bash
 >   echo "servicefabric servicefabric/accepted-eula-ga select true" | sudo debconf-set-selections
@@ -85,8 +82,7 @@ sudo apt-get install -fy
   At this point, you can deploy pre-built Service Fabric application packages or new ones based on guest containers or guest executables. Please check out more details at [How to run some sample projects](https://azure.microsoft.com/resources/samples/?sort=0&service=service-fabric).
 
 
->   [!TIP]
-    If you have an SSD disk avaiable, it is recommended to pass an SSD folder path using `--clusterdataroot` with devclustersetup.sh for superior performance.
+>   If you have an SSD disk avaiable, it is recommended to pass an SSD folder path using `--clusterdataroot` with devclustersetup.sh for superior performance.
 
 ## Set up the Service Fabric CLI
 


### PR DESCRIPTION
This PR adds a new docs folder as a placeholder for any new documentation we need to add until we have a final home them. 

Also added one new page on how to use the local build generated debian files to deploy a cluster. 