### PR TITLE
Reducing number of submodules pulled by boost and depth of git clone

### DIFF
--- a/src/prod/tools/linux/third-party/boost.sh
+++ b/src/prod/tools/linux/third-party/boost.sh
@@ -43,7 +43,7 @@ init()
 {
     _init_ ${REPO} ${TAG} ${SRC_DIR}
     cd ${SRC_DIR}
-    git submodule update --init --recursive
+    git submodule update --init --quiet -- tools/build tools/inspect libs/chrono libs/filesystem libs/test libs/random libs/regex libs/system libs/thread libs/timer
     prune_unused
 }
 

--- a/src/prod/tools/linux/third-party/config.sh
+++ b/src/prod/tools/linux/third-party/config.sh
@@ -93,9 +93,8 @@ _init_()
     local branch=$2
     local src_dir=$3
     mkdir -p ${src_dir}
-    git clone ${repo} ${src_dir}
+    git clone --depth 1 -b ${branch} -- ${repo} ${src_dir}
     cd ${src_dir}
-    git checkout ${branch}
 }
 
 # Delete the binary output dir.


### PR DESCRIPTION
This reduces the time and size of the third party dependency script.
```
deps directory size: 5.01GB-> 2.0GB
```

Boost installation is now faster as it only pulls the libraries it needs instead of every single submodule in the Boosty project.