### PR TITLE
Updating link in README.md to point to LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,6 @@ Service Fabric conceptual and reference documentation is available at [docs.micr
 ## Samples 
 For Service Fabric sample code, check out the [Azure Code Sample gallery](https://azure.microsoft.com/resources/samples/?service=service-fabric) or go straight to [Azure-Samples on GitHub](https://github.com/Azure-Samples?q=service-fabric).
 ## License 
-All Service Fabric open source projects are licensed under the [MIT License](LICENSE.txt).
+All Service Fabric open source projects are licensed under the [MIT License](LICENSE).
 ## Code of Conduct 
 All Service Fabric open source projects adopt the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Fixed a link in README.md to point to LICENSE instead of LICENSE.txt