### PR TITLE
Revert "Reducing number of submodules pulled by boost and depth of git clone"

### DIFF
--- a/src/prod/tools/linux/third-party/boost.sh
+++ b/src/prod/tools/linux/third-party/boost.sh
@@ -43,7 +43,7 @@ init()
 {
     _init_ ${REPO} ${TAG} ${SRC_DIR}
     cd ${SRC_DIR}
-    git submodule update --init --quiet -- tools/build tools/inspect libs/chrono libs/filesystem libs/test libs/random libs/regex libs/system libs/thread libs/timer
+    git submodule update --init --recursive
     prune_unused
 }
 

--- a/src/prod/tools/linux/third-party/config.sh
+++ b/src/prod/tools/linux/third-party/config.sh
@@ -93,8 +93,9 @@ _init_()
     local branch=$2
     local src_dir=$3
     mkdir -p ${src_dir}
-    git clone --depth 1 -b ${branch} -- ${repo} ${src_dir}
+    git clone ${repo} ${src_dir}
     cd ${src_dir}
+    git checkout ${branch}
 }
 
 # Delete the binary output dir.


### PR DESCRIPTION
Reverts Microsoft/service-fabric#32

Caused a build break with boost dependency. Will update and submit a new PR with additional testing