### PR TITLE
Need apt-transport-https

### DIFF
--- a/docs/install_packages_and_deploy_cluster.md
+++ b/docs/install_packages_and_deploy_cluster.md
@@ -50,6 +50,7 @@ To install the SDK and the associated runtime package via the apt-get command-li
 6. Refresh your package lists based on the newly added repositories.
 
     ```bash
+    sudo apt-get install apt-transport-https
     sudo apt-get update
     ```
 


### PR DESCRIPTION
Include instructions to install `apt-transport-https` package before `apt-get update`