### PR TITLE
More flexible copy/paste instructions for .deb install

### DIFF
--- a/docs/install_packages_and_deploy_cluster.md
+++ b/docs/install_packages_and_deploy_cluster.md
@@ -58,8 +58,8 @@ To install the SDK and the associated runtime package via the apt-get command-li
 After you have updated your sources, you can install the runtime and SDK, confirm the installation, and agree to the license agreement. Please cd to the location in the output directory where the debians are placed i.e. out/build.prod/FabricDrop/deb/. Install the runtime and sdk Debian packages named as servicefabric_x.x.x.x.deb and servicefabric_sdkcommon_y.y.y.deb, where x.x.x.x and y.y.y is the actual version numbers in the same of the file. Please replace the commands below with the actual files names in the folder 
 
 ```bash
-sudo dpkg -i servicefabric_x.x.x.x.deb && sudo apt-get install -fy
-sudo dpkg -i servicefabric_sdkcommon_x.x.x.deb && sudo apt-get install -fy
+sudo dpkg -i out/build.prod/FabricDrop/deb/servicefabric_*.deb && sudo apt-get install -fy
+sudo dpkg -i out/build.prod/FabricDrop/deb/servicefabric_sdkcommon_*.deb && sudo apt-get install -fy
 ```
 
 >   The following commands automate accepting the license for Service Fabric packages:

--- a/docs/install_packages_and_deploy_cluster.md
+++ b/docs/install_packages_and_deploy_cluster.md
@@ -58,7 +58,7 @@ To install the SDK and the associated runtime package via the apt-get command-li
 After you have updated your sources, you can install the runtime and SDK, confirm the installation, and agree to the license agreement. Please cd to the location in the output directory where the debians are placed i.e. out/build.prod/FabricDrop/deb/. Install the runtime and sdk Debian packages named as servicefabric_x.x.x.x.deb and servicefabric_sdkcommon_y.y.y.deb, where x.x.x.x and y.y.y is the actual version numbers in the same of the file. Please replace the commands below with the actual files names in the folder 
 
 ```bash
-sudo dpkg -i out/build.prod/FabricDrop/deb/servicefabric_*.deb && sudo apt-get install -fy
+sudo dpkg -i out/build.prod/FabricDrop/deb/servicefabric_6*.deb && sudo apt-get install -fy
 sudo dpkg -i out/build.prod/FabricDrop/deb/servicefabric_sdkcommon_*.deb && sudo apt-get install -fy
 ```
 


### PR DESCRIPTION
User following instructions can copy + paste these instructions to install the generated .deb packages (where its the first time; I'm not sure yet if the build system cleans up previous .deb before creating new ones)