### PR TITLE
Handle *.png as binary in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Enforce LF endings on Windows.  This is necessary
 # in order for the Linux docker container on Windows to work.
 * text eol=lf
+*.png binary


### PR DESCRIPTION
PNGs (some) contain bare CR bytes, and will be both corrupted and perpetually viewed as changed by git.