### PR TITLE
Daemonize build so it survives terminal restarts

### DIFF
--- a/runbuild.sh
+++ b/runbuild.sh
@@ -47,6 +47,7 @@ fi
 echo "Running a build with container $IMAGE_NAME:$DOCKER_VERSION..."
 docker run \
     --rm \
+    --name service-fabric-runbuild -d \
     --net=host \
     --cap-add=NET_ADMIN \
     -ti \
@@ -55,4 +56,5 @@ docker run \
     -v "$CDIR"/src:/src \
     -e "BUILD_PARAMS=$BUILD_PARAMS" \
     $IMAGE_NAME:$DOCKER_VERSION \
-    bash -c 'echo $BUILD_PARAMS && cd /out/ && /src/build.sh -all -d $BUILD_PARAMS'
+    bash -c 'echo $BUILD_PARAMS && cd /out/ && /src/build.sh -all -d $BUILD_PARAMS' && \
+docker logs -f service-fabric-runbuild


### PR DESCRIPTION
Perhaps this will benefit others too - I run a large temporary server on cloud infra,
ssh in, and run `./runbuild.sh`. Sometimes the ssh session dies and my build dies (e.g.
cafe wifi). This PR will allow docker to keep running the container til completion,
and user can `docker logs -f service-fabric-runbuild` to resume tailing logs.