### PR TITLE
Consistent use of $FabricLogRoot

### DIFF
--- a/src/prod/linuxsetup/runtime/scripts/deployfabric.sh
+++ b/src/prod/linuxsetup/runtime/scripts/deployfabric.sh
@@ -61,8 +61,8 @@ if [ ! -d /etc/servicefabric ]; then
     mkdir /etc/servicefabric
 fi
 echo -n ${FabricDataRoot} > /etc/servicefabric/FabricDataRoot
-echo -n ${FabricDataRoot}/log > /etc/servicefabric/FabricLogRoot
-echo -n ${FabricBinRoot} > /etc/servicefabric/FabricBinRoot
+echo -n ${FabricLogRoot}  > /etc/servicefabric/FabricLogRoot
+echo -n ${FabricBinRoot}  > /etc/servicefabric/FabricBinRoot
 echo -n ${FabricCodePath} > /etc/servicefabric/FabricCodePath
 
 export LD_LIBRARY_PATH=${FabricCodePath}

--- a/src/prod/linuxsetup/runtime/scripts/starthost.sh
+++ b/src/prod/linuxsetup/runtime/scripts/starthost.sh
@@ -45,7 +45,7 @@ fi
 # Start tracing
 echo "Starting tracing session"
 if command -v lttng >/dev/null 2>&1; then
-    ./Fabric/DCA.Code/lttng_handler.sh "${FabricDataRoot}/log/Traces"
+    ./Fabric/DCA.Code/lttng_handler.sh "${FabricLogRoot}/Traces"
 else
     echo "LTTng is not installed." >&2;
 fi


### PR DESCRIPTION
This will allow starthost.sh to be run with a non-standard $FabrciLogRoot