### PR TITLE
Add PID tracking to the ServiceFabric systemd services

### DIFF
--- a/src/prod/linuxsetup/runtime/scripts/servicefabric.service
+++ b/src/prod/linuxsetup/runtime/scripts/servicefabric.service
@@ -4,6 +4,7 @@ Description=ServiceFabric Daemon
 [Service]
 Type=simple
 ExecStart=/opt/microsoft/servicefabric/bin/starthost.sh
+ExecStartPost=/bin/sh -c 'umask 022; pgrep starthost.sh > /var/run/servicefabric.pid'
 WorkingDirectory=/opt/microsoft/servicefabric/bin
 Restart=always
 RestartSec=5s

--- a/src/prod/linuxsetup/runtime/scripts/servicefabricupdater.service
+++ b/src/prod/linuxsetup/runtime/scripts/servicefabricupdater.service
@@ -5,7 +5,7 @@ Description=ServiceFabric Updater Daemon
 Type=simple
 EnvironmentFile=/etc/servicefabric/servicefabricupdater.config
 ExecStart=/opt/microsoft/servicefabric/bin/doupgrade.sh $PathToTargetInfoFile
-ExecStartPost=/bin/sh -c 'umask 022; pgrep starthost.sh > /var/run/servicefabricupdater.pid'
+ExecStartPost=/bin/sh -c 'umask 022; pgrep doupgrade.sh > /var/run/servicefabricupdater.pid'
 Restart=on-failure
 RestartSec=5s
 

--- a/src/prod/linuxsetup/runtime/scripts/servicefabricupdater.service
+++ b/src/prod/linuxsetup/runtime/scripts/servicefabricupdater.service
@@ -5,6 +5,7 @@ Description=ServiceFabric Updater Daemon
 Type=simple
 EnvironmentFile=/etc/servicefabric/servicefabricupdater.config
 ExecStart=/opt/microsoft/servicefabric/bin/doupgrade.sh $PathToTargetInfoFile
+ExecStartPost=/bin/sh -c 'umask 022; pgrep starthost.sh > /var/run/servicefabricupdater.pid'
 Restart=on-failure
 RestartSec=5s
 


### PR DESCRIPTION
Adds PID tracking to the `servicefabric` and `servicefabricupdater` processes that are run by systemd for use in monitoring and other scripts. It modifies the systemd services to drop pidfiles in `/var/run/` in accordance with other services.