### PR TITLE
Construct the return value List with the proper capacity

### DIFF
--- a/src/prod/src/managed/Api/src/System/Fabric/OperationData.cs
+++ b/src/prod/src/managed/Api/src/System/Fabric/OperationData.cs
@@ -106,7 +106,7 @@ namespace System.Fabric
 
         private static unsafe IList<ArraySegment<byte>> CreateFromNativeInternal(uint count, IntPtr buffer)
         {
-            List<ArraySegment<byte>> returnValue = new List<ArraySegment<byte>>();
+            List<ArraySegment<byte>> returnValue = new List<ArraySegment<byte>>(count);
 
             for (int i = 0; i < count; i++)
             {


### PR DESCRIPTION
The final capacity is known. The list should be created with the proper capacity to avoid unnecessary re-allocations and copying.