### PR TITLE
Adding datatype attribute to parameter tag used by Settings

### DIFF
--- a/src/prod/src/ServiceModel/xsd/ServiceFabricServiceModel.xsd
+++ b/src/prod/src/ServiceModel/xsd/ServiceFabricServiceModel.xsd
@@ -3309,7 +3309,7 @@
           <xs:sequence>
             <xs:element name="Parameter" minOccurs="0" maxOccurs="unbounded">
               <xs:complexType>
-                <xs:attribute name="DataType" type="xs:string" use="optional" default="string"/>
+                <xs:attribute name="DataType" type="xs:string" default="string"/>
                 <xs:attribute name="Name" type="xs:string" use="required"/>
                 <xs:attribute name="Value" type="xs:string" use="required"/>
                 <xs:attribute name="MustOverride" type="xs:boolean" default="false">

--- a/src/prod/src/ServiceModel/xsd/ServiceFabricServiceModel.xsd
+++ b/src/prod/src/ServiceModel/xsd/ServiceFabricServiceModel.xsd
@@ -3309,6 +3309,7 @@
           <xs:sequence>
             <xs:element name="Parameter" minOccurs="0" maxOccurs="unbounded">
               <xs:complexType>
+                <xs:attribute name="DataType" type="xs:string" use="optional" default="string"/>
                 <xs:attribute name="Name" type="xs:string" use="required"/>
                 <xs:attribute name="Value" type="xs:string" use="required"/>
                 <xs:attribute name="MustOverride" type="xs:boolean" default="false">


### PR DESCRIPTION
Adding DataType attribute to the parameter tag in Settings which specifies the data type of the
setting (int, string, bool, etc) this would allow for the file to be parsed and have a static C# file with the settings values and their corresponding type.
allowing the settings to be used by the project without having to manually writing them into a settings definitions file somewhere in the project. 
issue: [https://github.com/Azure/service-fabric-issues/issues/1574](https://github.com/Azure/service-fabric-issues/issues/1574)