### PR TITLE
Enable usage of async foreach on SF IAsyncEnumerable

### DIFF
--- a/src/prod/src/managed/Microsoft.ServiceFabric.Data.Interfaces/IAsyncEnumerator.cs
+++ b/src/prod/src/managed/Microsoft.ServiceFabric.Data.Interfaces/IAsyncEnumerator.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ServiceFabric.Data
         ///  if the enumerator has passed the end of the collection.
         /// </returns>
         /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
-        Task<bool> MoveNextAsync(CancellationToken cancellationToken);
+        Task<bool> MoveNextAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sets the enumerator to its initial position, which is before the first element


### PR DESCRIPTION
This change will allow using `ServiceFabric.Data.IAsyncEnumerable<T>` in the `async foreach`, since it uses duck typing.
So instead of manually working with enumerator we can write:
```csharp
async Task SomeMethond(ServiceFabric.Data.IAsyncEnumerable<T> asyncEnumerable)
{
  await foreach(var item in asyncEnumerable)
  {
     /*  Some code that use item variable */
  }
}
```

This will NOT allow using the extension method of `System.Collection.Generic.IAsyncEnumerable<T>` like `WithCancelation` or `ConfigureAwait` in order to do that interface needs to be implemented.