### PR TITLE
Fixed typo in ServiceManifest file

### DIFF
--- a/src/prod/src/BlockStore/Service/SFBlockStore/BSGatewayService/PackageRoot/ServiceManifest.xml
+++ b/src/prod/src/BlockStore/Service/SFBlockStore/BSGatewayService/PackageRoot/ServiceManifest.xml
@@ -20,7 +20,7 @@
     </EntryPoint>
   </CodePackage>
 
-  <!-- Config package is the contents of the Config directoy under PackageRoot that contains an 
+  <!-- Config package is the contents of the Config directory under PackageRoot that contains an 
        independently-updateable and versioned set of custom configuration settings for your service. -->
   <ConfigPackage Name="Config" Version="1.0.0" />
 

--- a/src/prod/src/BlockStore/Service/SFBlockStore/SFBlockStoreService/PackageRoot/ServiceManifest.xml
+++ b/src/prod/src/BlockStore/Service/SFBlockStore/SFBlockStoreService/PackageRoot/ServiceManifest.xml
@@ -22,7 +22,7 @@
     </EntryPoint>
   </CodePackage>
 
-  <!-- Config package is the contents of the Config directoy under PackageRoot that contains an 
+  <!-- Config package is the contents of the Config directory under PackageRoot that contains an 
        independently-updateable and versioned set of custom configuration settings for your service. -->
   <ConfigPackage Name="Config" Version="1.0.0" />
 

--- a/src/prod/src/BlockStore/Service/SampleApplication/AppContainerE/HWServicePkg/ServiceManifest.xml
+++ b/src/prod/src/BlockStore/Service/SampleApplication/AppContainerE/HWServicePkg/ServiceManifest.xml
@@ -26,7 +26,7 @@
     -->
   </CodePackage>
 
-  <!-- Config package is the contents of the Config directoy under PackageRoot that contains an 
+  <!-- Config package is the contents of the Config directory under PackageRoot that contains an 
        independently-updateable and versioned set of custom configuration settings for your service. -->
   <ConfigPackage Name="Config" Version="1.0.0" />
 

--- a/src/prod/src/BlockStore/Service/SampleApplication/BlockStoreContainerLinux/MongoServicePkg/ServiceManifest.xml
+++ b/src/prod/src/BlockStore/Service/SampleApplication/BlockStoreContainerLinux/MongoServicePkg/ServiceManifest.xml
@@ -27,7 +27,7 @@
     -->
   </CodePackage>
 
-  <!-- Config package is the contents of the Config directoy under PackageRoot that contains an 
+  <!-- Config package is the contents of the Config directory under PackageRoot that contains an 
        independently-updateable and versioned set of custom configuration settings for your service. -->
   <ConfigPackage Name="Config" Version="1.0.0" />
 

--- a/src/prod/test/System.Fabric.Management/functional/ImageStoreService/PackageRoot/ImageStoreTestServicePkg/ServicePkg/Code/DummyApp/ServicePkg/ServiceManifest.xml
+++ b/src/prod/test/System.Fabric.Management/functional/ImageStoreService/PackageRoot/ImageStoreTestServicePkg/ServicePkg/Code/DummyApp/ServicePkg/ServiceManifest.xml
@@ -20,7 +20,7 @@
     </EntryPoint>
   </CodePackage>
 
-  <!-- Config package is the contents of the Config directoy under PackageRoot that contains an
+  <!-- Config package is the contents of the Config directory under PackageRoot that contains an
        independently-updateable and versioned set of custom configuration settings for your service. -->
   <ConfigPackage Name="Config" Version="1.0.0" />
 </ServiceManifest>

--- a/src/prod/test/System.Fabric.Management/functional/ImageStoreService/PackageRoot/ImageStoreTestServicePkg/ServicePkg/ServiceManifest.xml
+++ b/src/prod/test/System.Fabric.Management/functional/ImageStoreService/PackageRoot/ImageStoreTestServicePkg/ServicePkg/ServiceManifest.xml
@@ -20,7 +20,7 @@
     </EntryPoint>
   </CodePackage>
 
-  <!-- Config package is the contents of the Config directoy under PackageRoot that contains an
+  <!-- Config package is the contents of the Config directory under PackageRoot that contains an
        independently-updateable and versioned set of custom configuration settings for your service. -->
   <ConfigPackage Name="Config" Version="1.0.0" />
 

--- a/src/prod/test/System.Fabric.Management/functional/ImageStoreService/PackageRoot/ImageStoreTestServicePkg/ServicePkg/ServiceManifest_Linux.xml
+++ b/src/prod/test/System.Fabric.Management/functional/ImageStoreService/PackageRoot/ImageStoreTestServicePkg/ServicePkg/ServiceManifest_Linux.xml
@@ -20,7 +20,7 @@
     </EntryPoint>
   </CodePackage>
 
-  <!-- Config package is the contents of the Config directoy under PackageRoot that contains an
+  <!-- Config package is the contents of the Config directory under PackageRoot that contains an
        independently-updateable and versioned set of custom configuration settings for your service. -->
   <ConfigPackage Name="Config" Version="1.0.0" />
 


### PR DESCRIPTION
Fixed typo in ServiceManifest.xml filers: directoy => directory