### PR TITLE
enhancement add src/prod/src/managed/DCA/product/system.fabric.dca/DiskSpaceManager.cs add  Disk space remaining: {2}. to existing trace #1067

### DIFF
--- a/src/prod/src/managed/DCA/product/system.fabric.dca/DiskSpaceManager.cs
+++ b/src/prod/src/managed/DCA/product/system.fabric.dca/DiskSpaceManager.cs
@@ -356,9 +356,10 @@ namespace System.Fabric.Dca
             {
                 this.traceSource.WriteInfo(
                     TraceType,
-                    "Disk space user {0} was found to be using {1:N0}B of disk space.", 
+                    "Disk space user {0} was found to be using {1:N0}B of disk space. Disk space remaining: {2}.", 
                     userCount.Key,
-                    userCount.Value);
+                    userCount.Value,
+                    diskSpaceRemaining);
             }
 
             var totalDiskSpaceUsed = usageDictionary.Values.Sum();


### PR DESCRIPTION
fix for issue #1067 
src/prod/src/managed/DCA/product/system.fabric.dca/DiskSpaceManager.cs add  Disk space remaining: {2}. to existing trace

foreach (var userCount in usageDictionary)
            {
                this.traceSource.WriteInfo(
                    TraceType,
                    "Disk space user {0} was found to be using {1:N0}B of disk space. Disk space remaining: {2}.", 
                    userCount.Key,
                    userCount.Value,
                    diskSpaceRemaining);
            }
